### PR TITLE
fixed passing `limit` parameter on test

### DIFF
--- a/server.js
+++ b/server.js
@@ -981,7 +981,7 @@ app.get("/test-algo", function(req, res) {
   }
   // check for options from query data
   if (req.query.limit) {
-    testAlgoExec(res, {test: true, limit: 5});
+    testAlgoExec(res, {test: true, limit: req.query.limit});
   } else {
     res.status(200).send(
       html_testAlgo1


### PR DESCRIPTION
Fixed an issue where calling `/test-algo?limit=1500` would pass `limit=5` anyway.